### PR TITLE
Correct link to landing page in advert

### DIFF
--- a/doc/SIPS-2025_Advertisement.md
+++ b/doc/SIPS-2025_Advertisement.md
@@ -22,5 +22,7 @@ Sierralaya
 
 🔗 Learn more & register:
 
--   Landing page: <https://osf.io/xmjen/>
+-   Landing page:
+    <https://docs.google.com/document/d/1otQq3B6d2tUWNKw6AxodJdNAJk3s5Nb->
 -   Sign up!: <https://forms.gle/3mUf7mLTHoXgqX51A>
+


### PR DESCRIPTION
The link to the landing page pointed actually to the OSF repository instead.